### PR TITLE
Remove invalid domain

### DIFF
--- a/spotify
+++ b/spotify
@@ -750,7 +750,6 @@ timecapsule.spotify.com
 tpc.googlesyndication.
 tpc.googlesyndication.com
 track.leanlab.co
-track.leanlab.co(trackingpixel)
 tracking.admobsphere.com
 tribpubdfp745347008913.s.moatpixel.com
 tune.com


### PR DESCRIPTION
When adding https://raw.githubusercontent.com/vincentkenny01/spotblock/master/spotify to my pihole groups, I noticed the following error message

```
  [i] Target: https://raw.githubusercontent.com/vincentkenny01/spotblock/master/spotify
  [✓] Status: Retrieval successful
  [i] Received 507 domains, 1 domains invalid!
      Sample of invalid domains:
      - track.leanlab.co(trackingpixel)
```

This change removes the erroneous domain