### PR TITLE
Removes googlehosted.l.googleusercontent.com

### DIFF
--- a/spotify
+++ b/spotify
@@ -381,7 +381,6 @@ googleads4.g.doubleclick.net
 googleads.g.doubleclick.
 googleads.g.doubleclick.net
 googleadservices.com
-googlehosted.l.googleusercontent.com
 googletagservices.com
 groups.spotify.com 
 gtssl2-ocsp.geotrust.


### PR DESCRIPTION
When browsing Google Maps, I noticed that images are failing to load as a result of `lh5.googleusercontent.com` being blocked. After inspecting `dig` I noticed the following

```
➜  ~ dig +short lh5.googleusercontent.com
googlehosted.l.googleusercontent.com.
172.253.122.132
```

I've since added a whitelist for `googlehosted.l.googleusercontent.com` on my own PiHole but removing it from this list would likely help all other users of this list